### PR TITLE
Add `source_code_uri` to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.1.1 / 2024-01-01
+
+- RuboCop: Style/WordArray (7b5964f)
+- RuboCop: Style/StringLiteralsInInterpolation (152a44c)
+- Add source_code_uri to metadata (207db81)
+
 ## 5.1.0 / 2023-12-12
 
 - Remove upper Ruby version constraint (#52) (f34716e)

--- a/lib/link_header_parser/version.rb
+++ b/lib/link_header_parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LinkHeaderParser
-  VERSION = "5.1.0"
+  VERSION = "5.1.1"
 end

--- a/link-header-parser.gemspec
+++ b/link-header-parser.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/CHANGELOG.md",
-    "rubygems_mfa_required" => "true"
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }
 end


### PR DESCRIPTION
- Add source_code_uri to metadata
- Bump version and update CHANGELOG
